### PR TITLE
Fix AP IPAddress definitions for ESP8266

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -3,9 +3,9 @@
 
 namespace {
 constexpr char kAccessPointSsid[] = "MiniLabo";
-constexpr IPAddress kAccessPointIp(192, 168, 4, 1);
-constexpr IPAddress kAccessPointGateway(192, 168, 4, 1);
-constexpr IPAddress kAccessPointSubnet(255, 255, 255, 0);
+const IPAddress kAccessPointIp(192, 168, 4, 1);
+const IPAddress kAccessPointGateway(192, 168, 4, 1);
+const IPAddress kAccessPointSubnet(255, 255, 255, 0);
 }
 
 void setup() {


### PR DESCRIPTION
## Summary
- replace constexpr IPAddress definitions with const values to satisfy ESP8266 compilation requirements

## Testing
- ⚠️ `pio run` *(fails: command not found in container)*

------
https://chatgpt.com/codex/tasks/task_e_68d448564774832ea2ba4cff1cbd0080