### PR TITLE
Fix request body chunk concatenation

### DIFF
--- a/src/ui/WebServer.cpp
+++ b/src/ui/WebServer.cpp
@@ -62,8 +62,7 @@ bool WebServer::begin() {
     if (!body) {
       return;
     }
-    String chunk(reinterpret_cast<const char *>(data), len);
-    body->concat(chunk);
+    body->concat(reinterpret_cast<const char *>(data), len);
   });
 
   // Route statique pour servir les fichiers depuis LittleFS


### PR DESCRIPTION
## Summary
- append request body chunks directly using the String::concat overload that accepts a pointer and length
- avoid constructing temporary String instances for raw request body data

## Testing
- pio run *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68d466a70318832ead3528f1442004e6