### PR TITLE
Prevent login events from overriding OLED PIN display

### DIFF
--- a/src/ui/WebServer.cpp
+++ b/src/ui/WebServer.cpp
@@ -531,21 +531,16 @@ bool WebServer::begin() {
 
     if (type == F("page_load")) {
       OledPin::pushErrorMessage(F("Client login connecté"));
-      OledPin::setPinCode(0);
     } else if (type == F("pin_update")) {
-      String pinDigits = extractDigits(doc["pin"].as<String>());
-      int pinValue = pinDigits.length() ? pinDigits.toInt() : 0;
-      OledPin::setPinCode(pinValue);
+      // Ne pas modifier l'affichage du code PIN avec les entrées du client :
+      // cela masquerait le véritable code généré par l'appareil et
+      // empêcherait l'utilisateur de s'authentifier correctement.
+      // On se contente donc d'enregistrer l'évènement.
     } else if (type == F("login_result")) {
       bool success = doc["success"].as<bool>();
       String message = doc["message"].as<String>();
       if (!message.length()) {
         message = success ? F("Connexion OK") : F("PIN incorrect");
-      }
-      if (success) {
-        String pinDigits = extractDigits(doc["pin"].as<String>());
-        int pinValue = pinDigits.length() ? pinDigits.toInt() : 0;
-        OledPin::setPinCode(pinValue);
       }
       OledPin::pushErrorMessage(message);
     } else {


### PR DESCRIPTION
## Summary
- avoid overwriting the hardware PIN display when the web login page sends telemetry events
- keep the OLED showing the actual session PIN so users can authenticate successfully
- document the rationale with inline comments in the login event handler

## Testing
- attempted to run `platformio run` *(fails: platformio not installed in container)*

------
https://chatgpt.com/codex/tasks/task_e_68d5b74324ac832e9291b1355fc57fd6