### PR TITLE
Ensure web login uses session PIN

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -311,6 +311,7 @@ void setup() {
   g_sessionPin = generateSessionPin();
   generalDoc["pin"] = g_sessionPin;
   ConfigStore::requestSave("general");
+  WebServer::setExpectedPin(g_sessionPin);
 
   bool apStarted = startAccessPointVerbose();
   if (!apStarted) {

--- a/src/ui/WebServer.h
+++ b/src/ui/WebServer.h
@@ -21,12 +21,17 @@ public:
   static bool hasAuthenticatedClient();
   /** Boucle d'entretien (aucune action nécessaire actuellement). */
   static void loop() {}
+  /** Définit le code PIN attendu pour l'authentification HTTP. */
+  static void setExpectedPin(int pin);
+  /** Définit le code PIN attendu à partir d'une chaîne (utilisé par la config). */
+  static void setExpectedPin(const String& pin);
 private:
   static AsyncWebServer _server;
   static AsyncWebSocket _wsLogs;
   static int _logClients;
   static bool _started;
   static bool _hasAuthenticatedClient;
+  static String _expectedPin;
   static void logCallback(const String& line);
   static bool checkAuth(AsyncWebServerRequest *request);
   static String readRequestBody(AsyncWebServerRequest *request);


### PR DESCRIPTION
## Summary
- propagate the generated session PIN to the web server and keep a sanitized copy for authentication
- reuse the stored PIN when validating /login requests and refresh it when configuration changes

## Testing
- `pio run` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68d5b9a03e98832e9e26ea9d7bd2c431