### PR TITLE
Affiche les deux codes PIN sur l'OLED

### DIFF
--- a/src/OledPin.h
+++ b/src/OledPin.h
@@ -25,7 +25,11 @@ namespace OledPin {
   void pushErrorMessage(const String& message);
   /** Affiche le code PIN à l'écran. */
   void showPIN(int pin);
-  /** Définit le code PIN à afficher dans le bandeau de statut. */
+  /** Définit le code PIN de session à afficher dans le bandeau de statut. */
+  void setSessionPin(int pin);
+  /** Définit le code PIN attendu côté serveur Web. */
+  void setExpectedPin(const String& pin);
+  /** Définit le code PIN à afficher dans le bandeau de statut (session). */
   void setPinCode(int pin);
   /** Affiche un aperçu des IO après authentification. */
   void showIOValues(const std::vector<IOBase*>& ios);

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -323,7 +323,8 @@ void setup() {
   OledPin::begin();
   g_oledInitialised = true;
   flushDeferredOledMessages();
-  OledPin::setPinCode(g_sessionPin);
+  OledPin::setSessionPin(g_sessionPin);
+  OledPin::setExpectedPin(WebServer::expectedPin());
 
   Logger::begin();
   Logger::setLogCallback(handleLogLineForDisplay);

--- a/src/ui/WebServer.cpp
+++ b/src/ui/WebServer.cpp
@@ -395,6 +395,11 @@ void WebServer::setExpectedPin(int pin) {
 void WebServer::setExpectedPin(const String& pin) {
   _expectedPin = normalizePin(pin);
   _hasAuthenticatedClient = false;
+  OledPin::setExpectedPin(_expectedPin);
+}
+
+String WebServer::expectedPin() {
+  return _expectedPin;
 }
 
 namespace {

--- a/src/ui/WebServer.h
+++ b/src/ui/WebServer.h
@@ -25,6 +25,8 @@ public:
   static void setExpectedPin(int pin);
   /** Définit le code PIN attendu à partir d'une chaîne (utilisé par la config). */
   static void setExpectedPin(const String& pin);
+  /** Retourne le code PIN attendu actuellement normalisé sur 4 chiffres. */
+  static String expectedPin();
 private:
   static AsyncWebServer _server;
   static AsyncWebSocket _wsLogs;


### PR DESCRIPTION
## Summary
- afficher simultanément le code PIN généré et le code attendu par le serveur sur l’écran OLED
- stocker séparément les valeurs de session et de configuration avec normalisation et contrôle d’affichage
- exposer l’API côté serveur pour récupérer le PIN attendu et mettre à jour l’écran lors des changements

## Testing
- `platformio run` *(échoue : PlatformIO non installé dans l’environnement d’exécution)*

------
https://chatgpt.com/codex/tasks/task_e_68d5bd631b78832e9dfb6a461ecdccc6