### PR TITLE
Affiche les informations de login sur l'OLED

### DIFF
--- a/src/OledPin.h
+++ b/src/OledPin.h
@@ -31,6 +31,10 @@ namespace OledPin {
   void setExpectedPin(const String& pin);
   /** Définit le code PIN à afficher dans le bandeau de statut (session). */
   void setPinCode(int pin);
+  /** Mémorise le code PIN soumis par le client Web. */
+  void setSubmittedPin(const String& pin);
+  /** Affiche le résultat du test de connexion. */
+  void setTestStatus(const String& status);
   /** Affiche un aperçu des IO après authentification. */
   void showIOValues(const std::vector<IOBase*>& ios);
 }


### PR DESCRIPTION
## Summary
- affiche sur l'écran OLED le code PIN de session, le code fourni par la page de login et l'état du test
- mémorise côté firmware le dernier code soumis par le client et le message de résultat pour le reporter sur l'afficheur
- relaie les évènements /login pour mettre à jour l'affichage de debug lors des tentatives et des réponses

## Testing
- `platformio run` *(échoue : command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68d5c48a1ac0832e90b6ea374c199c68