### PR TITLE
Fix login body parsing fallback

### DIFF
--- a/src/ui/WebServer.cpp
+++ b/src/ui/WebServer.cpp
@@ -776,13 +776,41 @@ bool WebServer::checkAuth(AsyncWebServerRequest *request) {
 }
 
 String WebServer::readRequestBody(AsyncWebServerRequest *request) {
-  if (!request || !request->_tempObject) {
+  if (!request) {
     return String();
   }
-  String *body = static_cast<String *>(request->_tempObject);
-  String result = *body;
-  delete body;
-  request->_tempObject = nullptr;
+
+  String result;
+  if (request->_tempObject) {
+    String *body = static_cast<String *>(request->_tempObject);
+    if (body) {
+      result = *body;
+      delete body;
+    }
+    request->_tempObject = nullptr;
+  }
+
+  if (result.length() > 0) {
+    return result;
+  }
+
+  if (request->hasParam(F("plain"), true)) {
+    AsyncWebParameter *param = request->getParam(F("plain"), true);
+    if (param) {
+      result = param->value();
+      if (result.length() > 0) {
+        return result;
+      }
+    }
+  }
+
+  if (request->hasParam(F("plain"))) {
+    AsyncWebParameter *param = request->getParam(F("plain"));
+    if (param) {
+      result = param->value();
+    }
+  }
+
   return result;
 }
 


### PR DESCRIPTION
## Summary
- add robust handling in `WebServer::readRequestBody` to recover JSON bodies from AsyncWebServer requests even when the temporary buffer is empty
- fallback to the `plain` parameter so login and login-event endpoints receive the submitted PIN digits reliably

## Testing
- `pio run` *(fails: command not found in container)*

------
https://chatgpt.com/codex/tasks/task_e_68d5c8d71f5c832e9f8ac4e27f959596