### PR TITLE
Handle ADS1115 init failure gracefully

### DIFF
--- a/src/core/IORegistry.cpp
+++ b/src/core/IORegistry.cpp
@@ -112,11 +112,16 @@ float IO_ADS1115::readRaw() {
     ads = new Adafruit_ADS1115();
     if (!ads->begin(_address)) {
       Logger::error("IO", "ADS1115", String("Failed to init ADS1115 at 0x") + String(_address, HEX));
-      // Conserver l'instance malgré tout pour éviter les nullptr
+      delete ads;
+      ads = nullptr;
     }
     _adsDevices[_address] = ads;
   } else {
     ads = it->second;
+  }
+  if (!ads) {
+    // Périphérique indisponible : retourner une mesure nulle pour éviter les crashs.
+    return 0.0f;
   }
   // Configurer le gain en fonction de la pleine échelle souhaitée
   ads->setGain(pgaToGain(_pga));


### PR DESCRIPTION
## Summary
- stop reusing a failed ADS1115 driver instance by deleting it when initialization fails
- short-circuit ADS1115 readings when the device is unavailable to prevent watchdog resets

## Testing
- Not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68d6e064b7c8832e8b6913ecb1efc779